### PR TITLE
adjusted doc to reflect using rails command and not rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gem 'active_model_serializers', git: 'https://github.com/rails-api/active_model_
 Run this command:
 
 ```sh
-rake generate api_guardian:install
+rails generate api_guardian:install
 ```
 
 This will add an initializer, mount the routes, and, copy the migrations/seed files.


### PR DESCRIPTION
```
rake generate api_guardian:install --trace
rake aborted!
Don't know how to build task 'generate'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/task_manager.rb:62:in `[]'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:149:in `invoke_task'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:106:in `each'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:106:in `block in top_level'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:115:in `run_with_threads'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:100:in `top_level'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:78:in `block in run'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:176:in `standard_exception_handling'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rake/application.rb:75:in `run'
/Users/apshoemaker/.rvm/rubies/ruby-2.2.0/bin/rake:33:in `<main>'
```