### PR TITLE
Changed policy/application policy to account for multi-word models

### DIFF
--- a/lib/api_guardian/policies/application_policy.rb
+++ b/lib/api_guardian/policies/application_policy.rb
@@ -56,9 +56,9 @@ module ApiGuardian
       protected
 
       def resource_name
-        return record.new.class.name.demodulize.downcase if record.respond_to? :new
+        return record.new.class.name.demodulize.underscore if record.respond_to? :new
 
-        record.class.name.demodulize.downcase
+        record.class.name.demodulize.underscore
       end
     end
   end


### PR DESCRIPTION
"AptoModule" will now correctly be converted to "apto_module" instead of "aptomodule"