### PR TITLE
Upgrade kaminari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/dummy/log
 .DS_Store
 spec/tmp
 Gemfile.lock
+.idea

--- a/api_guardian.gemspec
+++ b/api_guardian.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'doorkeeper-grants_assertion', '~> 0.0.1'
   s.add_dependency 'doorkeeper-jwt', '~> 0.1'
   s.add_dependency 'doorkeeper', '~> 4.2'
-  s.add_dependency 'kaminari', '~> 0.17'
+  s.add_dependency 'kaminari', '~> 1.1.1'
   s.add_dependency 'koala', '~> 2.5'
   s.add_dependency 'paranoia', '~> 2.3'
   s.add_dependency 'pg', '~> 0.18'


### PR DESCRIPTION
I've upgrade kaminari from 0.17 to 1.1.1 because it contains a fix from 1.0.0.beta1, which address incorrect next links.

Hide Next & Last buttons if page is out of range #712 [@igorkasyanchuk]