### PR TITLE
force email to use lowercase email

### DIFF
--- a/lib/api_guardian/strategies/authentication/email.rb
+++ b/lib/api_guardian/strategies/authentication/email.rb
@@ -5,7 +5,7 @@ module ApiGuardian
         provides_authentication_for :email
 
         def authenticate(options)
-          user = ApiGuardian.configuration.user_class.find_by(email: options[:email])
+          user = ApiGuardian.configuration.user_class.find_by(email: options[:email].downcase)
           super(user: user)
           user if user && user.try(:authenticate, options[:password])
         end


### PR DESCRIPTION
The user model forces emails to lowercase, but the email auth strategy doesn't force email to lowercase. This fix, forces the email to lowercase.